### PR TITLE
 typescript-plugin-vue: Keep lib/ instead of dist/ after building package

### DIFF
--- a/packages/typescript-plugin-vue/package.json
+++ b/packages/typescript-plugin-vue/package.json
@@ -9,7 +9,7 @@
     "types": "lib/index.d.ts"
   },
   "files": [
-    "dist",
+    "lib",
     "runtime"
   ],
   "buildConfig": {


### PR DESCRIPTION
In `@vuedx/typescript-plugin-vue` package, the lib/ directory doesn't exist.

![Screenshot 2021-10-27 at 00 25 44](https://user-images.githubusercontent.com/1078179/138969759-98236530-f096-48e5-b36d-39756f789f80.png)